### PR TITLE
🎨 Palette: Add placeholder text to watermark input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -15,3 +15,7 @@
 ## 2024-05-26 - Formatting Sliders for Clarity
 **Learning:** Raw numeric sliders (like `0.0 - 2.0` or `0 - 255`) lack context and can be confusing to users. Using Streamlit's `format` parameter on `st.slider` (e.g., `format="%.1fx"` for multipliers, `format="%d%%"` for percentages) provides immediate clarity on the unit and effect of the slider. Furthermore, mapping technical values (like a 0-255 opacity) to a user-friendly 0-100 percentage scale greatly improves intuition.
 **Action:** Always use explicit string formatting for sliders to indicate units (px, %, x) and map underlying technical scales to intuitive user-facing scales where appropriate.
+
+## 2024-05-27 - Input Placeholders for Context
+**Learning:** Streamlit's `st.text_input` supports a `placeholder` argument. Providing explicit examples (e.g., "e.g. © 2024 MyBrand" for a Watermark field) improves usability by guiding the user on the expected input format without adding visual clutter like extra labels.
+**Action:** Always use the `placeholder` parameter for text inputs to provide clear, contextual examples.

--- a/src/app.py
+++ b/src/app.py
@@ -195,7 +195,7 @@ def main():
                 crop_aspect_h = st.number_input("Aspect Height", min_value=1, value=1, help="Height ratio (e.g., 9 for 16:9).")
 
     with st.sidebar.expander("Watermark", icon=":material/branding_watermark:"):
-        watermark_text = st.text_input("Watermark Text", max_chars=100, help="Text to overlay on the image.")
+        watermark_text = st.text_input("Watermark Text", max_chars=100, help="Text to overlay on the image.", placeholder="e.g. © 2024 MyBrand")
         if watermark_text:
             wm_opacity = st.slider("Opacity", 0, 100, 50, help="Transparency of the watermark.", format="%d%%")
             wm_opacity = int(round(wm_opacity * 255 / 100)) # map to 0-255 safely


### PR DESCRIPTION
Adds a helpful placeholder ("e.g. © 2024 MyBrand") to the watermark text input field to provide users with a clear example of the expected input format.

---
*PR created automatically by Jules for task [38194041334872206](https://jules.google.com/task/38194041334872206) started by @bstag*