### PR TITLE
🎨 Palette: Add degree formatting to rotation options

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -19,3 +19,7 @@
 ## 2024-05-27 - Input Placeholders for Context
 **Learning:** Streamlit's `st.text_input` supports a `placeholder` argument. Providing explicit examples (e.g., "e.g. © 2024 MyBrand" for a Watermark field) improves usability by guiding the user on the expected input format without adding visual clutter like extra labels.
 **Action:** Always use the `placeholder` parameter for text inputs to provide clear, contextual examples.
+
+## 2024-05-28 - Selectbox Formatting for Clarity
+**Learning:** Similar to sliders, raw numerical arrays in `st.selectbox` (like `[0, 90, 180, 270]` for rotation) can lack explicit unit context for the user. Streamlit's `st.selectbox` supports a `format_func` parameter that allows the displayed label to be modified (e.g., adding a degree symbol `°`) without changing the underlying value returned to the application logic.
+**Action:** Always consider using `format_func` on selectboxes to provide explicit units or more descriptive labels for technical enum values or numerical arrays.

--- a/src/app.py
+++ b/src/app.py
@@ -160,7 +160,7 @@ def main():
         filter_type = st.selectbox("Filter", ["None", "Blur", "Contour", "Detail", "Edge Enhance", "Emboss", "Sharpen", "Smooth"], index=0, help="Apply an image filter.")
 
     with st.sidebar.expander("Transforms", icon=":material/transform:"):
-        rotate = st.selectbox("Rotate", [0, 90, 180, 270], help="Rotate the image clockwise.")
+        rotate = st.selectbox("Rotate", [0, 90, 180, 270], format_func=lambda x: f"{x}°", help="Rotate the image clockwise.")
         col1, col2 = st.columns(2)
         with col1:
             flip_h = st.checkbox("Flip Horizontal", help="Mirror the image horizontally.")


### PR DESCRIPTION
💡 What: Added `format_func=lambda x: f"{x}°"` to the "Rotate" selectbox in `src/app.py`.
🎯 Why: Streamlit's `st.selectbox` previously displayed raw numbers (0, 90, 180, 270) which lacked explicit context. Adding the degree unit improves usability and clarity for the user without changing the underlying integer values passed to the image processing logic.
📸 Before/After: Shows `90°` instead of `90`.
♿ Accessibility: Improved cognitive accessibility by making the unit of measurement explicit. Also logged this learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [17960724603633079203](https://jules.google.com/task/17960724603633079203) started by @bstag*