### PR TITLE
🎨 Palette: Collapse labels in dominant color grid to reduce visual clutter

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -23,3 +23,7 @@
 ## 2024-05-28 - Selectbox Formatting for Clarity
 **Learning:** Similar to sliders, raw numerical arrays in `st.selectbox` (like `[0, 90, 180, 270]` for rotation) can lack explicit unit context for the user. Streamlit's `st.selectbox` supports a `format_func` parameter that allows the displayed label to be modified (e.g., adding a degree symbol `°`) without changing the underlying value returned to the application logic.
 **Action:** Always consider using `format_func` on selectboxes to provide explicit units or more descriptive labels for technical enum values or numerical arrays.
+
+## 2024-05-29 - Removing Visual Clutter with Collapsed Labels
+**Learning:** In Streamlit, when displaying arrays of items (like a color palette) where the visual representation is self-evident or accompanied by a separate caption, repeating the label (e.g., "Color 1", "Color 2") creates unnecessary visual clutter. Using `label_visibility="collapsed"` hides the label visually while keeping it accessible for screen readers.
+**Action:** Use `label_visibility="collapsed"` on repeating widgets in tight layouts when the context is clear or a custom caption is provided.

--- a/src/app.py
+++ b/src/app.py
@@ -452,7 +452,7 @@ def main():
                     cols = st.columns(len(item["dominant_colors"]))
                     for idx, color in enumerate(item["dominant_colors"]):
                         with cols[idx]:
-                            st.color_picker(f"Color {idx+1}", color, disabled=True, key=f"c_{name_stem}_{idx}")
+                            st.color_picker(f"Color {idx+1}", color, disabled=True, key=f"c_{name_stem}_{idx}", label_visibility="collapsed")
                             st.caption(color)
 
                 if item.get("histogram_data"):


### PR DESCRIPTION
💡 What: Added `label_visibility="collapsed"` to the `st.color_picker` used to display extracted dominant colors.
🎯 Why: In the Detailed Results view, the dominant color list previously displayed "Color 1", "Color 2", etc., directly above the color swatch, with the HEX code below it. This repeated labeling creates visual clutter, as the swatches and hex codes are self-explanatory.
📸 Before/After: The visual labels are now removed from the color boxes, resulting in a cleaner UI.
♿ Accessibility: By using `label_visibility="collapsed"` instead of removing the label entirely, screen readers will still announce "Color 1", "Color 2", maintaining full accessibility.

---
*PR created automatically by Jules for task [3926307436930456062](https://jules.google.com/task/3926307436930456062) started by @bstag*