### PR TITLE
🎨 Palette: Prevent transparency selection for unsupported formats

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-03-27 - Streamlit Expander Icons
 **Learning:** Adding icons to Streamlit `st.expander` components significantly improves the scannability of long lists of configuration options, providing immediate visual cues without taking up extra space.
 **Action:** Utilize the `icon` parameter for `st.expander` and similar container widgets in Streamlit to enhance visual hierarchy and ease of use, especially in sidebars with many settings.
+
+## 2024-05-01 - Error Prevention via Disabled States
+**Learning:** Preventing users from selecting conflicting options (like checking "Replace Color with Transparency" when the output format is JPEG/BMP) is a more effective and pleasant UX pattern than allowing the selection and then displaying a warning or error message. It shifts the interface from error recovery to error prevention.
+**Action:** When UI options are mutually exclusive or unsupported based on previous selections, explicitly disable the unavailable controls (`disabled=True` in Streamlit) and update the `help` text or provide a `st.caption` to explain why the option is unavailable, rather than waiting to show an error state later.

--- a/src/app.py
+++ b/src/app.py
@@ -214,12 +214,17 @@ def main():
         pixel_size = st.slider("Pixelate (Retro Effect)", 1, 100, 1, help="Increase to make the image look like 8-bit pixel art.", format="%dpx")
 
     with st.sidebar.expander("Transparency", icon=":material/opacity:"):
-        replace_color = st.checkbox("Replace Color with Transparency", help="Make a specific color transparent.")
-        if replace_color:
+        trans_disabled = output_format in ['JPEG', 'BMP']
+        trans_help = f"Transparency is not supported for {output_format} format." if trans_disabled else "Make a specific color transparent."
+
+        replace_color = st.checkbox("Replace Color with Transparency", help=trans_help, disabled=trans_disabled)
+
+        if trans_disabled:
+            st.caption(f"⚠️ Not supported for {output_format} format.")
+
+        if replace_color and not trans_disabled:
             trans_color = st.color_picker("Color to Replace", "#FFFFFF", help="Choose the color to make transparent.")
             trans_tolerance = st.slider("Tolerance", 0, 100, 10, help="How much variation in color to accept.", format="%d%%")
-            if output_format in ['JPEG', 'BMP']:
-                st.warning("Selected output format does not support transparency!")
 
     if 'processed_images' not in st.session_state:
         st.session_state.processed_images = None


### PR DESCRIPTION
🎨 Palette: Prevent transparency selection for unsupported formats

💡 What: Disabled the "Replace Color with Transparency" checkbox when JPEG or BMP format is selected.
🎯 Why: Shifts the UX from error recovery (showing a warning after checking) to error prevention (disabling the option entirely).
♿ Accessibility: Added clear explanations via `help` text and `st.caption` for screen readers and visual clarity.

---
*PR created automatically by Jules for task [5546444872484712444](https://jules.google.com/task/5546444872484712444) started by @bstag*