### PR TITLE
🎨 Palette: Disable transparency options for unsupported formats

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,7 @@
 ## 2024-05-29 - Removing Visual Clutter with Collapsed Labels
 **Learning:** In Streamlit, when displaying arrays of items (like a color palette) where the visual representation is self-evident or accompanied by a separate caption, repeating the label (e.g., "Color 1", "Color 2") creates unnecessary visual clutter. Using `label_visibility="collapsed"` hides the label visually while keeping it accessible for screen readers.
 **Action:** Use `label_visibility="collapsed"` on repeating widgets in tight layouts when the context is clear or a custom caption is provided.
+
+## 2024-05-30 - Error Prevention via Disabled States
+**Learning:** In Streamlit applications, allowing users to select options that are mutually exclusive or unsupported by other settings (e.g., choosing "Replace Color with Transparency" when the output format is "JPEG") and then displaying a warning later creates a frustrating "Error Recovery" flow. Proactively disabling the unsupported controls and updating their `help` text to explain *why* they are disabled shifts the UX to "Error Prevention", making the interface much more intuitive.
+**Action:** Always dynamically disable UI controls that are not applicable based on current selections and provide clear explanations in tooltips (`help` parameter) or `st.caption` to proactively prevent user error.

--- a/src/app.py
+++ b/src/app.py
@@ -214,12 +214,19 @@ def main():
         pixel_size = st.slider("Pixelate (Retro Effect)", 1, 100, 1, help="Increase to make the image look like 8-bit pixel art.", format="%dpx")
 
     with st.sidebar.expander("Transparency", icon=":material/opacity:"):
-        replace_color = st.checkbox("Replace Color with Transparency", help="Make a specific color transparent.")
-        if replace_color:
+        transparency_disabled = output_format in ['JPEG', 'BMP']
+        transparency_help = "Make a specific color transparent."
+        if transparency_disabled:
+            transparency_help = f"Make a specific color transparent. (Disabled: {output_format} does not support transparency)"
+
+        replace_color = st.checkbox(
+            "Replace Color with Transparency",
+            help=transparency_help,
+            disabled=transparency_disabled
+        )
+        if replace_color and not transparency_disabled:
             trans_color = st.color_picker("Color to Replace", "#FFFFFF", help="Choose the color to make transparent.")
             trans_tolerance = st.slider("Tolerance", 0, 100, 10, help="How much variation in color to accept.", format="%d%%")
-            if output_format in ['JPEG', 'BMP']:
-                st.warning("Selected output format does not support transparency!")
 
     if 'processed_images' not in st.session_state:
         st.session_state.processed_images = None


### PR DESCRIPTION
💡 What: Disabled the "Replace Color with Transparency" checkbox and updated its tooltip when the selected output format (JPEG or BMP) does not support transparency.

🎯 Why: To prevent user frustration by shifting from an "error recovery" flow (warning after an invalid selection) to an "error prevention" flow (proactively disabling invalid selections).

📸 Before/After: N/A (Functional/state change, no visual layout changes)

♿ Accessibility: The disabled state and dynamic `help` parameter clearly communicate the restriction to screen readers without adding visual clutter.

---
*PR created automatically by Jules for task [1981258122088950239](https://jules.google.com/task/1981258122088950239) started by @bstag*