### PR TITLE
🎨 Palette: [UX improvement] Add CTA after image upload

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,7 @@
 ## 2024-05-29 - Removing Visual Clutter with Collapsed Labels
 **Learning:** In Streamlit, when displaying arrays of items (like a color palette) where the visual representation is self-evident or accompanied by a separate caption, repeating the label (e.g., "Color 1", "Color 2") creates unnecessary visual clutter. Using `label_visibility="collapsed"` hides the label visually while keeping it accessible for screen readers.
 **Action:** Use `label_visibility="collapsed"` on repeating widgets in tight layouts when the context is clear or a custom caption is provided.
+
+## 2024-05-30 - Transitional Empty States
+**Learning:** Between an initial empty state (no data) and a completed state (processed results), there is often a "transitional state" where data exists but action is required. If the UI relies on an action button placed far from the data input or if the user flow isn't linear, users can stall in this state. Adding context-aware calls to action (CTAs) that appear specifically in this transitional phase bridges the gap.
+**Action:** Always map the full user journey. Identify states where the user has provided input but the application requires further action to produce results, and add explicit instructional UI (like `st.info` with a directional icon) to guide the next step.

--- a/src/app.py
+++ b/src/app.py
@@ -401,6 +401,8 @@ def main():
                 # Store in session state
                 st.session_state.processed_images = processed_images
                 st.toast("Processing Complete!", icon='🎉')
+        elif not st.session_state.processed_images:
+            st.info("👈 **Configure settings in the sidebar**, then click **Process** above to transform your images.", icon="💡")
 
     # Display Results if available in session state
     if st.session_state.processed_images:


### PR DESCRIPTION
**💡 What**: Added a transitional empty state CTA (`st.info`) that appears after a user has uploaded images but before they click "Process".

**🎯 Why**: Resolves a UX gap where the welcome screen disappears after upload, leaving users with just a "Process" button. This explicitly guides them to configure sidebar settings first.

**📸 Before/After**: 
Before: Upload -> Blank screen + Process Button.
After: Upload -> Helpful `st.info` prompting user to check the sidebar -> Process Button.

**♿ Accessibility**: Improves cognitive accessibility by providing clear, context-aware instructions instead of relying on user recall or discovery.

---
*PR created automatically by Jules for task [308038362807123267](https://jules.google.com/task/308038362807123267) started by @bstag*