### PR TITLE
🎨 Palette: [UX improvement] Disable irrelevant SVG settings in binary mode

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,7 @@
 ## 2024-05-30 - Transitional Empty States
 **Learning:** Between an initial empty state (no data) and a completed state (processed results), there is often a "transitional state" where data exists but action is required. If the UI relies on an action button placed far from the data input or if the user flow isn't linear, users can stall in this state. Adding context-aware calls to action (CTAs) that appear specifically in this transitional phase bridges the gap.
 **Action:** Always map the full user journey. Identify states where the user has provided input but the application requires further action to produce results, and add explicit instructional UI (like `st.info` with a directional icon) to guide the next step.
+
+## 2024-06-05 - SVG Settings Contextual Disabling
+**Learning:** In the vectorization (SVG) settings, options like "Color Precision" and "Gradient Threshold" were enabled even when "Black & White (Binary)" mode was selected, leading to confusion as these sliders have no effect in binary mode.
+**Action:** Applied the "Error Prevention via Disabled States" pattern by dynamically setting `disabled=True` for these sliders when the color mode is "binary", and updated their `help` tooltips to clarify why they are disabled.

--- a/src/app.py
+++ b/src/app.py
@@ -93,8 +93,14 @@ def main():
             hierarchical = st.selectbox("Layering", ["stacked", "cutout"], index=0, format_func=lambda x: "Stacked" if x == "stacked" else "Cutout", help="Stacked = layers on top of each other. Cutout = no overlapping.")
             mode = st.selectbox("Curve Mode", ["spline", "polygon", "none"], index=0, format_func=lambda x: x.capitalize(), help="Curve smoothing method.")
             filter_speckle = st.slider("Filter Speckle", 0, 128, 4, help="Remove small noise (pixels).", format="%dpx")
-            color_precision = st.slider("Color Precision", 1, 8, 6, help="Number of significant bits to use (lower = fewer colors).", format="%d bits")
-            layer_difference = st.slider("Gradient Threshold", 0, 128, 16, help="Threshold for color difference.", format="%d")
+
+            is_binary = colormode == "binary"
+            color_precision_help = "Not applicable in Black & White mode." if is_binary else "Number of significant bits to use (lower = fewer colors)."
+            color_precision = st.slider("Color Precision", 1, 8, 6, disabled=is_binary, help=color_precision_help, format="%d bits")
+
+            layer_diff_help = "Not applicable in Black & White mode." if is_binary else "Threshold for color difference."
+            layer_difference = st.slider("Gradient Threshold", 0, 128, 16, disabled=is_binary, help=layer_diff_help, format="%d")
+
             corner_threshold = st.slider("Corner Threshold", 0, 180, 60, help="Minimum angle to be considered a corner.", format="%d°")
 
     if quality_disabled:


### PR DESCRIPTION
**What:**
Added logic to disable the "Color Precision" and "Gradient Threshold" sliders in the SVG Settings expander when the "Black & White (Binary)" Color Mode is selected. Also updated the `help` text for both sliders to explicitly state they are not applicable in this mode.

**Why:**
Previously, these sliders remained active even when "Black & White (Binary)" was selected, allowing users to tweak settings that had no effect on the output. By explicitly disabling these sliders and providing a clear explanation in the tooltip, we shift the UX from error recovery (wondering why the sliders do nothing) to error prevention, reducing cognitive load and making the interface more intuitive.

**Before/After:**
*   **Before:** Selecting "Black & White (Binary)" left "Color Precision" and "Gradient Threshold" active and adjustable, with their original tooltips.
*   **After:** Selecting "Black & White (Binary)" instantly greys out both sliders, preventing interaction, and their tooltips update to read: "Not applicable in Black & White mode."

**Accessibility:**
This change improves accessibility by reducing cognitive load and preventing users (especially those relying on screen readers or keyboard navigation) from interacting with non-functional UI elements, clearly communicating the system's current state and constraints.

---
*PR created automatically by Jules for task [13337076144253104698](https://jules.google.com/task/13337076144253104698) started by @bstag*