### PR TITLE
🎨 Palette: [UX improvement] Enhance discoverability with visible disabled states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -35,3 +35,7 @@
 ## 2024-06-05 - SVG Settings Contextual Disabling
 **Learning:** In the vectorization (SVG) settings, options like "Color Precision" and "Gradient Threshold" were enabled even when "Black & White (Binary)" mode was selected, leading to confusion as these sliders have no effect in binary mode.
 **Action:** Applied the "Error Prevention via Disabled States" pattern by dynamically setting `disabled=True` for these sliders when the color mode is "binary", and updated their `help` tooltips to clarify why they are disabled.
+
+## 2024-06-06 - Visible Disabled States for Discoverability
+**Learning:** Hiding dependent options completely (like removing Watermark settings when no text is provided) reduces discoverability and can confuse users who are looking for those settings but haven't taken the prerequisite action yet.
+**Action:** Show dependent options at all times but set `disabled=True`. This acts as a "teaser" to encourage user interaction and prevents confusion about where settings are located. When disabling, update the `help` parameter to explain exactly what action is needed to enable the setting.

--- a/src/app.py
+++ b/src/app.py
@@ -207,15 +207,15 @@ def main():
 
     with st.sidebar.expander("Watermark", icon=":material/branding_watermark:"):
         watermark_text = st.text_input("Watermark Text", max_chars=100, help="Text to overlay on the image.", placeholder="e.g. © 2024 MyBrand")
-        if watermark_text:
-            wm_opacity = st.slider("Opacity", 0, 100, 50, help="Transparency of the watermark.", format="%d%%")
-            wm_opacity = int(round(wm_opacity * 255 / 100)) # map to 0-255 safely
-            wm_size = st.number_input("Font Size", min_value=10, max_value=200, value=30, help="Size of the watermark text.")
-            wm_color = st.color_picker("Text Color", "#FFFFFF", help="Color of the watermark text.")
-        else:
-            wm_opacity = 128
-            wm_size = 30
-            wm_color = "#FFFFFF"
+
+        wm_disabled = not bool(watermark_text)
+        wm_disabled_help = "Enter Watermark Text above to enable this setting."
+
+        wm_opacity_slider = st.slider("Opacity", 0, 100, 50, help=wm_disabled_help if wm_disabled else "Transparency of the watermark.", format="%d%%", disabled=wm_disabled)
+        wm_opacity = int(round(wm_opacity_slider * 255 / 100)) # map to 0-255 safely
+
+        wm_size = st.number_input("Font Size", min_value=10, max_value=200, value=30, help=wm_disabled_help if wm_disabled else "Size of the watermark text.", disabled=wm_disabled)
+        wm_color = st.color_picker("Text Color", "#FFFFFF", help=wm_disabled_help if wm_disabled else "Color of the watermark text.", disabled=wm_disabled)
 
     with st.sidebar.expander("Analysis", icon=":material/analytics:"):
         extract_colors = st.checkbox("Extract Dominant Colors", help="Find and display the top 5 colors in the image.")


### PR DESCRIPTION
## What
This PR updates the Watermark expander section to use "Visible Disabled States" rather than hiding dependent UI options when no Watermark Text is provided.

## Why
Hiding dependent options (like Watermark opacity, size, and color) completely reduces discoverability. Users might wonder where the setting is if they haven't yet typed anything in the text input. Showing these options in a disabled state acts as a "teaser" and encourages the user to provide the required input.

## Before/After
- **Before:** If Watermark Text was empty, Opacity, Font Size, and Text Color inputs were removed from the UI.
- **After:** Opacity, Font Size, and Text Color are always visible. If Watermark Text is empty, they are disabled with a tooltip explaining: "Enter Watermark Text above to enable this setting."

## Accessibility
The changes improve usability and predictability, setting clearer expectations on what controls will be available once the text input is satisfied.

---
*PR created automatically by Jules for task [3220800981946054089](https://jules.google.com/task/3220800981946054089) started by @bstag*