### PR TITLE
🛡️ Sentinel: [security improvement] Strict Filename Sanitization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,8 @@
 **Vulnerability:** Pillow's default `Image.MAX_IMAGE_PIXELS` limit was higher than the application's intended limits, and raising `DecompressionBombError` led to unhandled exceptions with full stack traces in the logs (DoS via log spam / memory exhaustion before the application logic checked dimensions).
 **Learning:** Security validations at the application layer (`MAX_IMAGE_DIMENSION`) are only effective if the underlying library (Pillow) doesn't parse or allocate memory for malicious files first. Global library limits must be aligned with application limits.
 **Prevention:** Always explicitly configure underlying library protection limits (e.g., `Image.MAX_IMAGE_PIXELS`) and catch library-specific security exceptions (`Image.DecompressionBombError`) to handle them gracefully without leaking system state or spamming logs.
+
+## 2024-05-26 - Strict Filename Sanitization for Defense in Depth
+**Vulnerability:** A vulnerability existed where Windows-specific malicious paths (like `C:malicious.jpeg` or Alternate Data Streams like `file.jpg:hidden`) could bypass basic `os.path.basename` sanitization and be written into ZIP archives or the filesystem.
+**Learning:** `os.path.basename` does not fully strip all OS-specific dangerous characters on all platforms (e.g. it won't strip `:` on Unix when processing a Windows-style path). A strict allowlist regex (like `[^a-zA-Z0-9_\-\. ]`) is too aggressive and breaks internationalized filenames (like `résumé.pdf` or `你好.jpg`).
+**Prevention:** Use a targeted exclusion regex (e.g., `re.sub(r'[:*?"<>|]', '_', safe_name)`) *after* `os.path.basename` to explicitly strip specific illegal OS characters without breaking non-ASCII unicode filenames.

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import uuid
 from typing import List, Tuple, Union, IO, Any
 
@@ -53,6 +54,11 @@ def get_safe_filename_stem(filename: str) -> str:
 
     # Replace backslashes with forward slashes for cross-platform compatibility
     safe_name = os.path.basename(filename.replace("\\", "/"))
+
+    # Remove illegal characters (e.g. drive letters, ADS, etc) for defense-in-depth
+    # We use a pattern that specifically targets dangerous characters rather than an allowlist
+    # to avoid breaking non-ASCII/internationalized filenames.
+    safe_name = re.sub(r'[:*?"<>|]', '_', safe_name)
 
     # Handle cases like "" or ".." or "."
     if not safe_name or safe_name.strip('.') == '':

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -36,6 +36,11 @@ class TestSecurity(unittest.TestCase):
         self.assertEqual(get_safe_filename_stem("/etc/passwd.jpg"), "passwd")
         self.assertEqual(get_safe_filename_stem("malicious\0.jpg"), "malicious")
         self.assertEqual(get_safe_filename_stem(".."), "image")
+        self.assertEqual(get_safe_filename_stem("C:malicious.jpeg"), "C_malicious")
+        self.assertEqual(get_safe_filename_stem("file.jpg:hidden"), "file")
+        self.assertEqual(get_safe_filename_stem("a*b?c<d>e|f.png"), "a_b_c_d_e_f")
+        self.assertEqual(get_safe_filename_stem("résumé.pdf"), "résumé")
+        self.assertEqual(get_safe_filename_stem("你好.jpg"), "你好")
 
     def test_validate_upload_constraints(self):
         """


### PR DESCRIPTION
🚨 Severity: LOW/MEDIUM
💡 Vulnerability: Windows-specific malicious paths (like `C:malicious.jpeg` or Alternate Data Streams like `file.jpg:hidden`) could bypass basic `os.path.basename` sanitization when running on a non-Windows OS, and could be written into ZIP archives.
🎯 Impact: This could potentially lead to Zip Slip or OS-level file writing vulnerabilities when the resulting ZIP file is extracted on a Windows machine.
🔧 Fix: Enhanced filename sanitization by adding a targeted regex (`re.sub(r'[:*?"<>|]', '_', safe_name)`) to explicitly remove dangerous characters like drive letters (`:`) and other illegal OS characters (`<, >, |, ?, *`) while preserving non-ASCII/internationalized filenames.
✅ Verification: Tested the sanitization utility with unit tests, ensuring `C:malicious.jpeg` becomes `C_malicious`, and international characters like `résumé.pdf` are preserved.

---
*PR created automatically by Jules for task [5774575219573934277](https://jules.google.com/task/5774575219573934277) started by @bstag*